### PR TITLE
Aumentar tamaño de letra en componentes del menú principal.

### DIFF
--- a/src/components/Buscador.tsx
+++ b/src/components/Buscador.tsx
@@ -5,6 +5,7 @@ import styles from "./css/Buscador.module.css";
 import { supabase } from "../services/supabase";
 import { Accesibilidad } from "../interfaces/Accesibilidad";
 import { useTheme } from "../components/Footer/Modo_Nocturno";
+import { useFontSize } from "./Footer/Modificador_Letras";
 
 interface Marcador {
     id: number;
@@ -19,6 +20,7 @@ interface BuscadorProps {
 
 function Buscador({ onSeleccionMarcador }: BuscadorProps) {
     const { modoNocturno } = useTheme();
+    const {fontSize} = useFontSize ();
     const [filtroIsVisible, setFiltroIsVisible] = useState(false);
     const [width, setWidth] = useState(window.innerWidth <= 768 ? "65%" : "300px");
     const [height, setHeight] = useState("0px");
@@ -132,7 +134,7 @@ function Buscador({ onSeleccionMarcador }: BuscadorProps) {
         <div className={`${styles.container} ${modoNocturno ? styles.darkMode : ''}`}
             style={{
                 width: width,
-                transition: "width 0.3s ease",
+                transition: "width 0.3s ease"
             }}
         >
             <div style={{backgroundColor: modoNocturno ? "#2d2d2d" : ""}} className={styles.distribucionContainer}>
@@ -144,7 +146,7 @@ function Buscador({ onSeleccionMarcador }: BuscadorProps) {
                 <input
                     type="text"
                     className={`${styles.inpBuscar}`}
-                    style={{backgroundColor:modoNocturno ? "#2d2d2d" : "", color: modoNocturno ? "white": ""}}
+                    style={{backgroundColor:modoNocturno ? "#2d2d2d" : "", color: modoNocturno ? "white": "",fontSize : `${fontSize}rem`}}
                     placeholder="Buscador"
                     onChange={(e) => setBusqueda(e.target.value)}
                     value={busqueda}
@@ -203,6 +205,7 @@ function Buscador({ onSeleccionMarcador }: BuscadorProps) {
                     backgroundColor: modoNocturno ? '#333' : 'white', 
                     borderRadius: '10px', 
                     padding: '10px',
+                    fontSize:  `${fontSize}rem` ,
                     color: modoNocturno ? 'white' : 'black'
                 }}>
                     <p>Resultados</p>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -8,6 +8,7 @@ import styles from "./css/Footer.module.css";
 import TrazadoRuta from './TrazadoRuta';
 import User from './User';
 import Microfono from "./Microfono";
+import { useFontSize } from "./Modificador_Letras";
 
 interface Props {
     onSeleccionMarcador: (id: number) => void;
@@ -34,11 +35,12 @@ export default function Footer({
     const { user } = useAuth();
     const { modoNocturno } = useTheme(); // Usar el contexto del tema
     const [panelActivo, setPanelActivo] = useState<"map" | "user" | "microphone" | null>(null);
-    const [tamanoFuente, setTamanoFuente] = useState(1)
+    
     const [width, setWidth] = useState(window.innerWidth <= 768 ? "80%" : "300px");
     const setHeight = useState("0px")[1];
     const [Isdisplay, setIsdisplay] = useState("none");
     const [activarReconocimiento, setactivarReconocimiento] = useState(false);
+    const {fontSize} = useFontSize ();
 
     useEffect(() => {
         const handleResize = () => {
@@ -99,21 +101,10 @@ export default function Footer({
         }, 300);
     };
 
-    const aumentarFuente = () => {
-        if (tamanoFuente < 1.5) {
-            setTamanoFuente(tamanoFuente + 0.1)
-        }
-    }
-
-    const disminuirFuente = () => {
-        if (tamanoFuente > 0.8) {
-            setTamanoFuente(tamanoFuente - 0.1)
-        }
-    }
-
+    
     return (
         <div className={`${styles.ContenPrin} ${modoNocturno ? styles.darkMode : ''}`} 
-             style={{ fontSize: `${tamanoFuente}rem`, width: width }}>
+             style={{ fontSize: `${fontSize}rem`, width: width }}>
 
             <div className={styles.ContenButton}>
                 <button onClick={() => togglePanel("map")} className={styles.Button}>
@@ -142,7 +133,7 @@ export default function Footer({
                 }}>
                 
                 {panelActivo === "map" && <TrazadoRuta 
-                    tamanoFuente={tamanoFuente} 
+                    
                     closePanel={closePanel} 
                     panelActivo={panelActivo}
                     onSeleccionMarcadorRecientes={onSeleccionMarcador} 
@@ -153,16 +144,15 @@ export default function Footer({
                     onIndicaciones={onIndicaciones}/>}
 
                 {panelActivo === "user" && <User 
-                    tamanoFuente={tamanoFuente} 
+                   
                     closePanel={closePanel} 
                     panelActivo={panelActivo} 
                     user={user} 
                     navigate={navigate}
-                    disminuirFuente={disminuirFuente} 
-                    aumentarFuente={aumentarFuente} />}
+                    
+                     />}
 
                 {panelActivo === "microphone" && <Microfono 
-                    tamanoFuente={tamanoFuente} 
                     closePanel={closePanel}
                     panelActivo={panelActivo} 
                     activarReconocimiento={activarReconocimiento} />}

--- a/src/components/Footer/Microfono.tsx
+++ b/src/components/Footer/Microfono.tsx
@@ -3,27 +3,26 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleXmark } from "@fortawesome/free-solid-svg-icons";
 import Reconocimiento from "../../components/Footer/reconocimientodevoz";
 import { useTheme } from "./Modo_Nocturno";
-
+import { useFontSize } from "./Modificador_Letras";
 
 
 export default function Microfono({
-    tamanoFuente,
     closePanel,
     panelActivo,
     activarReconocimiento,
 }: {
-    tamanoFuente: number;
     closePanel: () => void;
     panelActivo: string;
     activarReconocimiento: boolean;
 }) {
 
     const {modoNocturno} = useTheme ();
+    const {fontSize} = useFontSize ();
 
     return (
         <div>
             {panelActivo === "microphone" && ( //Vista de la funcion que realiza el Microphone
-                <div className={styles.PanelActivo} style={{ fontSize: `${tamanoFuente}rem` }}>
+                <div className={styles.PanelActivo} style={{ fontSize: `${fontSize}rem` }}>
                     {panelActivo !== null && (
                         <button
                             onClick={closePanel} className={styles.ButtonClose}>

--- a/src/components/Footer/Modificador_Letras.tsx
+++ b/src/components/Footer/Modificador_Letras.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+interface FontSizeContextType {
+  fontSize: number;
+  increaseFontSize: () => void;
+  decreaseFontSize: () => void;
+}
+
+const FontSizeContext = createContext<FontSizeContextType | undefined>(undefined);
+
+export const useFontSize = () => {
+  const context = useContext(FontSizeContext);
+  if (!context) {
+    throw new Error('useFontSize debe ser usado dentro de un FontSizeProvider');
+  }
+  return context;
+};
+
+export const FontSizeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [fontSize, setFontSize] = useState(() => {
+    // Recuperar el tamaño de fuente del localStorage al iniciar
+    const saved = localStorage.getItem('fontSize');
+    return saved ? parseFloat(saved) : 1;
+  });
+
+  // Guardar en localStorage cuando cambie
+  useEffect(() => {
+    localStorage.setItem('fontSize', fontSize.toString());
+  }, [fontSize]);
+
+  const increaseFontSize = () => {
+    if (fontSize < 1.5) {
+      setFontSize(prevSize => Math.round((prevSize + 0.1) * 10) / 10);
+    }
+  };
+
+  const decreaseFontSize = () => {
+    if (fontSize > 0.8) {
+      setFontSize(prevSize => Math.round((prevSize - 0.1) * 10) / 10);
+    }
+  };
+
+  return (
+    <FontSizeContext.Provider value={{ fontSize, increaseFontSize, decreaseFontSize }}>
+      {children}
+    </FontSizeContext.Provider>
+  );
+};

--- a/src/components/Footer/TrazadoRuta.tsx
+++ b/src/components/Footer/TrazadoRuta.tsx
@@ -5,10 +5,10 @@ import { supabase } from '../../services/supabase';
 import { useState, useEffect } from 'react';
 import { useTheme } from "./Modo_Nocturno";
 import { useAuth } from "../../hooks/useAuth";
+import { useFontSize } from "./Modificador_Letras";
 
 
 export default function TrazadoRuta({ 
-    tamanoFuente, 
     closePanel, 
     panelActivo, 
     onSeleccionMarcadorRecientes, 
@@ -18,7 +18,6 @@ export default function TrazadoRuta({
     Idrutamarcador,
     onIndicaciones
 }: {
-    tamanoFuente: number,
     closePanel: () => void
     panelActivo: string
     onSeleccionMarcadorRecientes: (id: number) => void
@@ -40,6 +39,7 @@ export default function TrazadoRuta({
     const [destinoEstablecido, setDestinoEstablecido] = useState<boolean>(false);
     const [modoViajeActual, setModoViajeActual] = useState<'DRIVING' | 'BICYCLING' | 'WALKING' | 'TRANSIT'>('DRIVING');
     const {modoNocturno} = useTheme ();
+    const {fontSize} = useFontSize ();
 
 
     useEffect(() => {
@@ -149,7 +149,7 @@ export default function TrazadoRuta({
         <div>
             {panelActivo === "map" && (
 
-                <div className={styles.PanelActivo} style={{ fontSize: `${tamanoFuente}rem` }}>
+                <div className={styles.PanelActivo} style={{ fontSize: `${fontSize}rem` }}>
                     <button onClick={closePanel} className={styles.ButtonClose}>
                         <FontAwesomeIcon icon={faCircleXmark} style={{ color: "red" }} size="xl" />
                     </button>
@@ -158,7 +158,7 @@ export default function TrazadoRuta({
                             <div className={styles.ContenInterUno}>
                                 <FontAwesomeIcon icon={faLocationCrosshairs} size="sm" />
                             </div>
-                            <input style={{pointerEvents: "none", cursor: "not-allowed"}}
+                            <input style={{pointerEvents: "none", cursor: "not-allowed",fontSize:  `${fontSize}rem` ,}}
                                 type="text"
                                 value={ubicacionActiva ? "Ubicación Activa" : "Ubicación Desactivada"}
                                 readOnly
@@ -173,7 +173,7 @@ export default function TrazadoRuta({
                             </div>
                             <div style={{ position: "relative", width: "100%" }}>
                             <input
-                                    style={{color: modoNocturno ? "white":""}}
+                                    style={{color: modoNocturno ? "white":"",fontSize:  `${fontSize}rem` }}
                                     type="text"
                                     placeholder="Destino"
                                     className={styles.Input}
@@ -191,6 +191,7 @@ export default function TrazadoRuta({
                                 />
                             {busqueda.length > 0 && mostrarResultados && (
                                     <div style={{
+                                        fontSize:  `${fontSize}rem` ,
                                         position: "absolute",
                                         width: "100%",
                                         backgroundColor: modoNocturno ? "#2d2d2d" : 'white',
@@ -206,6 +207,7 @@ export default function TrazadoRuta({
                                                 <div
                                                     key={item.id}
                                                     style={{
+                                                        fontSize:  `${fontSize}rem` ,
                                                         padding: "5px 0",
                                                         borderBottom: "1px solid #eee",
                                                         cursor: "pointer"
@@ -222,7 +224,7 @@ export default function TrazadoRuta({
                                                 </div>
                                             ))
                                         ) : (
-                                            <p style={{ marginTop: "10px", color: "#888" }}>Sin resultados.</p>
+                                            <p style={{ marginTop: "10px", color: "#888", fontSize:  `${fontSize}rem` , }}>Sin resultados.</p>
                                         )}
                                     </div>
                                 )}
@@ -255,7 +257,7 @@ export default function TrazadoRuta({
                                 DESTINOS RECIENTES
                             </h4>
                             {!destinosRecientes ? (
-                                <p style={{color:modoNocturno ? "#fff" : ""}} className={styles.MensajeP}>No hay Destinos Recientes</p>
+                                <p style={{color:modoNocturno ? "#fff" : "",fontSize:`${fontSize}rem`}} className={styles.MensajeP}>No hay Destinos Recientes</p>
                             ) : (
                                 busquedasRecientes.map((busquedas, index) => (
                                     <div key={index} className={styles.ContenInfo} onClick={() => onSeleccionMarcadorRecientes(busquedas.id_marcador?.id)}>
@@ -287,7 +289,7 @@ export default function TrazadoRuta({
                             <div key={index} className={styles.ContenInfo}>
                               <div>
                                 <p
-                                  style={{ margin: "0", fontWeight: "bold", color: modoNocturno ? "white" : "black" }}
+                                  style={{ margin: "0", fontWeight: "bold", color: modoNocturno ? "white" : "black", fontSize:  `${fontSize}rem` , }}
                                   dangerouslySetInnerHTML={{ __html: instruccion }}
                                 />
                               </div>

--- a/src/components/Footer/User.tsx
+++ b/src/components/Footer/User.tsx
@@ -3,31 +3,28 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleXmark, faPlus, faMinus } from "@fortawesome/free-solid-svg-icons";
 import { useAuth } from "../../hooks/useAuth";
 import { useTheme } from "./Modo_Nocturno";
+import { useFontSize } from "./Modificador_Letras";
+
 
 export default function User({
-    tamanoFuente,
     closePanel,
     panelActivo,
     navigate,
-    disminuirFuente,
-    aumentarFuente,
 }: {
-    tamanoFuente: number;
     closePanel: () => void;
     panelActivo: string;
     user?: { email?: string };
     navigate: (path: string) => void;
-    disminuirFuente: () => void;
-    aumentarFuente: () => void;
 }) {
     const { userRole, user } = useAuth();
     const { modoNocturno, setModoNocturno } = useTheme();
+    const { fontSize, increaseFontSize, decreaseFontSize } = useFontSize(); // Usar el contexto
 
     return (
         <div>
             {panelActivo === "user" && (
                 <div className={`${styles.PanelActivo} ${modoNocturno ? styles.darkMode : ''}`} 
-                     style={{ fontSize: `${tamanoFuente}rem` }}>
+                     style={{ fontSize: `${fontSize}rem` }}>
                     <div style={{ flexDirection: "column" }}>
                         <button onClick={closePanel} className={styles.ButtonClose}>
                             <FontAwesomeIcon icon={faCircleXmark} style={{ color: "red" }} size="xl" />
@@ -57,7 +54,7 @@ export default function User({
                                 </button>
                             )}
                             <div>
-                                <button className={styles.ButtonColab} 
+                                <button style={{fontSize: `${fontSize}rem` }} className={styles.ButtonColab} 
                                         onClick={() => { navigate('/colaborar') }}>
                                     Colaborar
                                 </button>
@@ -72,21 +69,21 @@ export default function User({
                                           style={{ left: modoNocturno ? "22px" : "2px" }}></span>
                                 </div>
                             </div>
-                            <button className={styles.ButtonCompact}>
+                            <button style={{fontSize: `${fontSize}rem`}} className={styles.ButtonCompact}>
                                 Modo Compacto
                             </button>
                         </div>
                         <div className={styles.ContenFuncion}>
                             <div style={{ display: "flex" }}>
                                 <button
-                                    onClick={disminuirFuente} 
+                                    onClick={decreaseFontSize} 
                                     className={styles.MenosFuente}>
                                     <FontAwesomeIcon icon={faMinus} size="xs" style={{ color: modoNocturno ? "white" : "black" }} />
                                     <span className={styles.MenosA}>A</span>
                                 </button>
                                 <span className={styles.TituloFuente}>Tamaño de fuente</span>
                                 <button
-                                    onClick={aumentarFuente} 
+                                    onClick={increaseFontSize} 
                                     className={styles.MasFuente}>
                                     <span className={styles.MasA}>A</span>
                                     <FontAwesomeIcon icon={faPlus} size="xs" style={{ color: modoNocturno ? "white" : "black" }} />

--- a/src/components/NavbarUser.tsx
+++ b/src/components/NavbarUser.tsx
@@ -5,12 +5,14 @@ import { useNavigate } from "react-router-dom";
 import styles from './css/NavbarUser.module.css'
 import { useState } from "react";
 import { useTheme } from "./Footer/Modo_Nocturno";
+import { useFontSize } from "./Footer/Modificador_Letras";
 
 export default function NavbarUser() {
     const { user, signOut } = useAuth()
     const navigate = useNavigate()
     const [modalOpen, setModalOpen] = useState(false)
     const {modoNocturno} = useTheme ();
+    const {fontSize} = useFontSize ();
 
 
     if (!user) return null
@@ -29,18 +31,18 @@ export default function NavbarUser() {
             </div>
 
             {modalOpen == true && (
-                <div style={{ backgroundColor: modoNocturno ? "#2d2d2d" : 'white', borderRadius: '15px', padding: 10, pointerEvents: 'auto', width: '200px' }}>
-                    <div >
-                        <p style={{ color: modoNocturno ? "#fff" : "" ,fontWeight: 400, cursor: 'pointer', textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden' }}>{user?.user_metadata.full_name} </p>
-                        <p style={{ fontSize: '0.9rem', color: modoNocturno ? "#fff" :'gray', textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden' }}>{user?.email} </p>
+                <div style={{ backgroundColor: modoNocturno ? "#2d2d2d" : 'white', borderRadius: '15px', padding: 10, pointerEvents: 'auto', width: '200px'}}>
+                    <div>
+                        <p style={{ color: modoNocturno ? "#fff" : "" ,fontWeight: 400, cursor: 'pointer', textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden',fontSize:  `${fontSize}rem`  }}>{user?.user_metadata.full_name} </p>
+                        <p style={{ fontSize:  `${fontSize}rem` , color: modoNocturno ? "#fff" :'gray', textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden' }}>{user?.email} </p>
 
                     </div>
                     <div className={styles.opt}>
-                        <button className={styles.btnNavegacion} onClick={() => { navigate(`/usuario/perfil/${user.id}`) }} style={{ color: modoNocturno ? "#fff":"",display: 'block' }}>Ver perfil</button>
-                        <button className={styles.btnNavegacion} onClick={() => { navigate(`/usuarios/editar/${user.id}`) }} style={{ color: modoNocturno ? "#fff":"",display: 'block' }}>Editar perfil</button>
+                        <button className={styles.btnNavegacion} onClick={() => { navigate(`/usuario/perfil/${user.id}`) }} style={{ fontSize:  `${fontSize}rem` ,color: modoNocturno ? "#fff":"",display: 'block' }}>Ver perfil</button>
+                        <button className={styles.btnNavegacion} onClick={() => { navigate(`/usuarios/editar/${user.id}`) }} style={{ fontSize:  `${fontSize}rem` ,color: modoNocturno ? "#fff":"",display: 'block' }}>Editar perfil</button>
                     </div>
 
-                    <button className={styles.btnCerrarSesion} onClick={signOut}>
+                    <button style={{fontSize:  `${fontSize}rem` }} className={styles.btnCerrarSesion} onClick={signOut}>
                         Cerrar Sesion  <FontAwesomeIcon icon={faRightFromBracket} />
                     </button>
                 </div>

--- a/src/components/botoneventos.tsx
+++ b/src/components/botoneventos.tsx
@@ -8,11 +8,13 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import useGetCalendario from "../hooks/GetCalendario";
 import { useTheme } from "../components/Footer/Modo_Nocturno";
+import { useFontSize } from "./Footer/Modificador_Letras";
 
 function BotonEventos() {
   const [EventoIsVisible, setEventoIsVisible] = useState(false);
   const { events, error } = useGetCalendario();
   const {modoNocturno} = useTheme ();
+  const {fontSize} = useFontSize ();
 
   const toggleEventos = () => {
     setEventoIsVisible((prev) => !prev);
@@ -40,8 +42,8 @@ function BotonEventos() {
           cursor: "pointer",
         }}
       >
-        <FontAwesomeIcon icon={faCalendar} style={{ color: modoNocturno ? "white": "black" }} />
-        <p style={{ margin: 0, color: modoNocturno ? "white" : "black", fontSize: "1rem" }}>Eventos</p>
+        <FontAwesomeIcon icon={faCalendar} style={{ color: modoNocturno ? "white": "black", fontSize:`${fontSize}rem`}} />
+        <p style={{ margin: 0, color: modoNocturno ? "white" : "black", fontSize: `${fontSize}rem` }}>Eventos</p>
       </button>
 
       <div
@@ -67,8 +69,8 @@ function BotonEventos() {
                 gap: "5px",
               }}
             >
-              <FontAwesomeIcon icon={faAngleUp} size="2x" style={{ color: modoNocturno ? "#fff" :"black" }} />
-              <p style={{ margin: 0, color: modoNocturno ? "white" : "black", fontSize: "1rem" }}>Ocultar</p>
+              <FontAwesomeIcon icon={faAngleUp} size="2x" style={{ color: modoNocturno ? "#fff" :"black", fontSize:`${fontSize}rem` }} />
+              <p style={{ margin: 0, color: modoNocturno ? "white" : "black", fontSize: `${fontSize}rem`}}>Ocultar</p>
             </button>
 
             {error ? (
@@ -76,7 +78,7 @@ function BotonEventos() {
                 style={{
                   textAlign: "center",
                   color: "red",
-                  fontSize: "1.2rem",
+                  fontSize: `${fontSize}rem`,
                   fontWeight: "bold",
                 }}
               >
@@ -93,7 +95,7 @@ function BotonEventos() {
                 }}
               >
                 {events.length === 0 && (
-                  <div style={{ textAlign: "center", color: "gray", fontSize: "1rem" }}>
+                  <div style={{ textAlign: "center", color: "gray", fontSize: `${fontSize}rem` }}>
                     No hay eventos próximos
                   </div>
                 )}
@@ -102,6 +104,7 @@ function BotonEventos() {
                   <div key={event.id} style={{ paddingBottom: "10px" }}>
                     <div
                       style={{
+                        fontSize:`${fontSize}rem`,
                         width: "100%",
                         height: "1px",
                         backgroundColor: "black",
@@ -143,12 +146,12 @@ function BotonEventos() {
                             alignItems: "center",
                           }}
                         >
-                          <h3 style={{ margin: 0, fontSize: "1rem", fontWeight: "600" }}>
+                          <h3 style={{ margin: 0, fontSize: `${fontSize}`, fontWeight: "600" }}>
                             {event.title}
                           </h3>
                           <span
                             style={{
-                              fontSize: "0.7rem",
+                              fontSize: `${fontSize}rem`,
                               color: event.colorStatus,
                               textTransform: "uppercase",
                               textAlign: "center",
@@ -160,7 +163,7 @@ function BotonEventos() {
                         <p
                           style={{
                             margin: "5px 0",
-                            fontSize: "0.9rem",
+                            fontSize: `${fontSize}rem`,
                             opacity: 0.6,
                           }}
                         >
@@ -171,7 +174,7 @@ function BotonEventos() {
                             display: "flex",
                             alignItems: "center",
                             gap: "5px",
-                            fontSize: "0.9rem",
+                            fontSize: `${fontSize}rem`,
                             marginTop: "10px",
                             color: "#00570a",
                           }}
@@ -186,7 +189,7 @@ function BotonEventos() {
                             display: "flex",
                             alignItems: "center",
                             gap: "5px",
-                            fontSize: "0.9rem",
+                            fontSize: `${fontSize}rem`,
                             color: "#00570a",
                             marginTop: "10px",
                           }}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,17 @@ import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 import { BrowserRouter } from 'react-router-dom'
+import { ThemeProvider } from './components/Footer/Modo_Nocturno'
+import { FontSizeProvider } from './components/Footer/Modificador_Letras.tsx'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter >
-      <App />
+      <ThemeProvider>
+        <FontSizeProvider>
+        <App />
+        </FontSizeProvider>
+      </ThemeProvider>
 
     </BrowserRouter>
   </React.StrictMode>,

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -6,7 +6,7 @@ import BotonEventos from "../components/botoneventos";
 import VerMarcador from "../components/VerMarcador";
 import NavbarUser from "../components/NavbarUser";
 import { useAuth } from "../hooks/useAuth";
-import { ThemeProvider } from "../components/Footer/Modo_Nocturno";
+import { useTheme } from "../components/Footer/Modo_Nocturno";
 import { faLocationCrosshairs } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -25,6 +25,7 @@ export default function Home() {
   const { userEstado, signOut } = useAuth()
   const [yaVerificado, setYaVerificado] = useState(false);
   const [mapacentrado, setMapacentrado] = useState(false);
+  const {modoNocturno} = useTheme ();
 
   useEffect(() => {
     if (userEstado === false && !yaVerificado) {
@@ -72,7 +73,7 @@ export default function Home() {
   };
 
   return (
-<ThemeProvider>
+
     <div style={{ width: '100%', height: '100vh', position: 'relative' }}>
       <Map
         onSeleccionMarcador={(id: number) => {
@@ -141,11 +142,9 @@ export default function Home() {
               }
               disabled={!ubicacionActiva}
               style={{
+                background: modoNocturno ? "#2d2d2d" : "",
                 backgroundColor: !ubicacionActiva
-                  ? "#ccc"
-                  : mapacentrado
-                    ? "#4285F4"
-                    : "#fff",
+                ? modoNocturno ? "#666" : "#ccc" : mapacentrado ? "#4285F4" : modoNocturno ? "#2d2d2d" : "#fff" ,
                 border: "none",
                 borderRadius: "5px",
                 boxShadow: "0 1px 4px rgba(0,0,0,0.3)",
@@ -160,7 +159,7 @@ export default function Home() {
             >
               <FontAwesomeIcon
                 icon={faLocationCrosshairs}
-                color={!ubicacionActiva ? "#888" : mapacentrado ? "#fff" : "#666"}
+                color={!ubicacionActiva ? "#888" : mapacentrado ? "#fff" :( modoNocturno ? "#ddd" : "#666")}
                 style={{ width: "22px", height: "22px" }}
               />
             </button>
@@ -180,6 +179,5 @@ export default function Home() {
       )
       }
     </div >
-  </ThemeProvider>
   );
 }


### PR DESCRIPTION
Se reubicó el <ThemeProvider> desde Home.tsx a main.tsx para evitar conflictos jerárquicos en la ejecución. Esto permite aplicar correctamente los cambios de tema (como el modo nocturno) sin afectar visualmente a otros componentes de la app.

Además, se aplico modo nocturno a centrar ubicación.